### PR TITLE
Fix exit on syntax error

### DIFF
--- a/crates/shell/src/main.rs
+++ b/crates/shell/src/main.rs
@@ -21,15 +21,24 @@ fn commands() -> HashMap<String, Rc<dyn ShellCommand>> {
 }
 
 async fn execute(text: &str, state: &mut ShellState) -> anyhow::Result<i32> {
-    let list = deno_task_shell::parser::parse(text)?;
+    let list = deno_task_shell::parser::parse(text);
+
+    let mut stderr = ShellPipeWriter::stderr();
+    let stdout = ShellPipeWriter::stdout();
+    let stdin = ShellPipeReader::stdin();
+
+    if let Err(e) = list {
+        let _ = stderr.write_line(&format!("Syntax error: {}", e));
+        return Ok(1);
+    }
 
     // spawn a sequential list and pipe its output to the environment
     let result = execute_sequential_list(
-        list,
+        list.unwrap(),
         state.clone(),
-        ShellPipeReader::stdin(),
-        ShellPipeWriter::stdout(),
-        ShellPipeWriter::stderr(),
+        stdin,
+        stdout,
+        stderr,
         AsyncCommandBehavior::Wait,
     )
     .await;


### PR DESCRIPTION
Temporarily fix exiting on syntax error in interactive shell as mentioned in #33. This will be updated upon miette support. 