### PR TITLE
feat: support empty cd to go to the home directory

### DIFF
--- a/crates/deno_task_shell/src/shell/commands/cd.rs
+++ b/crates/deno_task_shell/src/shell/commands/cd.rs
@@ -38,7 +38,13 @@ impl ShellCommand for CdCommand {
 }
 
 fn execute_cd(cwd: &Path, args: Vec<String>) -> Result<PathBuf> {
-  let path = parse_args(args)?;
+  // create a new vector to avoid modifying the original
+  let mut args = args;
+  if args.is_empty() {
+    // append `~` to args
+    args.push("~".to_string());
+  }
+  let path = parse_args(args.clone())?;
   let new_dir = if path == "~" {
     dirs::home_dir()
       .ok_or_else(|| anyhow::anyhow!("Home directory not found"))?


### PR DESCRIPTION
Fixes #32

```console
% cargo r
   Compiling deno_task_shell v0.17.0 (/Users/pranavchiku/repos/shell/crates/deno_task_shell)
   Compiling shell v0.1.0 (/Users/pranavchiku/repos/shell/crates/shell)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.12s
     Running `target/debug/shell`
~/repos/shell$ cd
~$ ls
[...]
```