### PR TITLE
add multiline test script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +278,7 @@ dependencies = [
  "dirs",
  "futures",
  "glob",
+ "insta",
  "os_pipe",
  "parking_lot",
  "path-dedot",
@@ -328,6 +341,12 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "endian-type"
@@ -546,6 +565,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +607,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +627,12 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1005,6 +1048,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "slab"

--- a/crates/deno_task_shell/Cargo.toml
+++ b/crates/deno_task_shell/Cargo.toml
@@ -29,6 +29,7 @@ pest_derive = "2.7.12"
 dirs = "5.0.1"
 
 [dev-dependencies]
+insta = "1.40.0"
 parking_lot = "0.12.3"
 pretty_assertions = "1"
 serde_json = "1.0.128"

--- a/crates/deno_task_shell/src/grammar.pest
+++ b/crates/deno_task_shell/src/grammar.pest
@@ -1,7 +1,6 @@
-// grammar.pest
-
 // Whitespace and comments
-WHITESPACE = _{ " " | "\t" | ("\\" ~ WHITESPACE* ~ NEWLINE) }
+WHITESPACE = _{ " " | "\t" | ESCAPED_NEWLINE }
+ESCAPED_NEWLINE = _{ "\\" ~ NEWLINE }
 COMMENT = _{ "#" ~ (!NEWLINE ~ ANY)* }
 
 // Basic tokens
@@ -25,11 +24,13 @@ QUOTED_PENDING_WORD = ${ (
     QUOTED_ESCAPE_CHAR | 
     SUB_COMMAND | 
     ("$" ~ VARIABLE) |
-    QUOTED_CHAR
+    QUOTED_CHAR |
+    NEWLINE |
+    ESCAPED_NEWLINE
 )* }
 
 UNQUOTED_ESCAPE_CHAR = ${ ("\\" ~ "$" | "$" ~ !"(" ~ !VARIABLE) | "\\" ~ (" " | "`" | "\"" | "(" | ")")* }
-QUOTED_ESCAPE_CHAR = ${ "\\" ~ "$" | "$" ~ !"(" ~ !VARIABLE | "\\" ~ ("`" | "\"" | "(" | ")" | "'")* }
+QUOTED_ESCAPE_CHAR = @{ "\\" ~ ("$" | "`" | "\"" | "(" | ")" | "'" | "\n" | "\r\n") }
 
 UNQUOTED_CHAR = ${ ("\\" ~ " ") | !("(" | ")" | "{" | "}" | "<" | ">" | "|" | "&" | ";" | "\"" | "'" | "$") ~ ANY }
 QUOTED_CHAR = ${ !"\"" ~ ANY }
@@ -38,12 +39,11 @@ VARIABLE = ${ (ASCII_ALPHANUMERIC | "_")+ }
 SUB_COMMAND = { "$(" ~ complete_command ~ ")" }
 
 DOUBLE_QUOTED = @{ "\"" ~ QUOTED_PENDING_WORD ~ "\"" }
-SINGLE_QUOTED = @{ "'" ~ (!"'" ~ ANY)* ~ "'" }
+SINGLE_QUOTED = @{ "'" ~ (!"'" ~ (NEWLINE | ESCAPED_NEWLINE | ANY))* ~ "'" }
 
 NAME = ${ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 ASSIGNMENT_WORD = { NAME ~ "=" ~ UNQUOTED_PENDING_WORD? }
 IO_NUMBER = @{ ASCII_DIGIT+ }
-
 // Special tokens
 AND_IF = { "&&" }
 OR_IF = { "||" }
@@ -59,7 +59,6 @@ DLESSDASH = { "<<-" }
 CLOBBER = { ">|" }
 AMPERSAND = { "&" }
 EXIT_STATUS = ${ "$?" }
-
 
 // Operators
 OPERATOR = _{
@@ -203,8 +202,8 @@ filename = _{ FILE_NAME_PENDING_WORD }
 io_here = !{ (DLESS | DLESSDASH) ~ here_end }
 here_end = @{ ("\"" ~ UNQUOTED_PENDING_WORD ~ "\"") | UNQUOTED_PENDING_WORD }
 
-newline_list = _{ NEWLINE+ }
-linebreak = _{ NEWLINE* }
+newline_list = _{ (NEWLINE | ESCAPED_NEWLINE)+ }
+linebreak = _{ (NEWLINE | ESCAPED_NEWLINE)* }
 separator_op = { "&" | ";" }
 separator = _{ separator_op ~ linebreak | newline_list }
 sequential_sep = !{ ";" ~ linebreak | newline_list }

--- a/crates/deno_task_shell/src/lib.rs
+++ b/crates/deno_task_shell/src/lib.rs
@@ -7,7 +7,7 @@
 pub mod parser;
 
 #[cfg(feature = "shell")]
-mod shell;
+pub mod shell;
 
 #[cfg(feature = "shell")]
 pub use shell::*;

--- a/crates/deno_task_shell/src/parser.rs
+++ b/crates/deno_task_shell/src/parser.rs
@@ -677,7 +677,6 @@ fn parse_subshell(pair: Pair<Rule>) -> Result<Command> {
 
 fn parse_word(pair: Pair<Rule>) -> Result<Word> {
   let mut parts = Vec::new();
-
   match pair.as_rule() {
     Rule::UNQUOTED_PENDING_WORD => {
       for part in pair.into_inner() {
@@ -803,10 +802,14 @@ fn parse_quoted_word(pair: Pair<Rule>) -> Result<WordPart> {
         match part.as_rule() {
           Rule::EXIT_STATUS => parts.push(WordPart::Text("$?".to_string())),
           Rule::QUOTED_ESCAPE_CHAR => {
+            let val = &part.as_str()[1..];
+            if val == "\n" {
+              continue;
+            }
             if let Some(WordPart::Text(ref mut s)) = parts.last_mut() {
-              s.push_str(part.as_str());
+              s.push_str(val);
             } else {
-              parts.push(WordPart::Text(part.as_str().to_string()));
+              parts.push(WordPart::Text(val.to_string()));
             }
           }
           Rule::SUB_COMMAND => {
@@ -990,7 +993,6 @@ mod test {
         .map_err(|e| anyhow::Error::msg(e.to_string()))?
         .next()
         .unwrap();
-      //   println!("pairs: {:?}", pairs);
       parse_complete_command(pairs)
     };
 

--- a/crates/deno_task_shell/src/shell/mod.rs
+++ b/crates/deno_task_shell/src/shell/mod.rs
@@ -26,4 +26,4 @@ mod types;
 #[cfg(test)]
 mod test;
 #[cfg(test)]
-mod test_builder;
+pub mod test_builder;

--- a/crates/deno_task_shell/src/shell/snapshots/deno_task_shell__shell__test__multiline.snap
+++ b/crates/deno_task_shell/src/shell/snapshots/deno_task_shell__shell__test__multiline.snap
@@ -1,0 +1,8 @@
+---
+source: crates/deno_task_shell/src/shell/test.rs
+expression: stdout
+---
+foo     bla
+foo
+    bla
+foo " bar

--- a/crates/deno_task_shell/src/shell/test.rs
+++ b/crates/deno_task_shell/src/shell/test.rs
@@ -1,11 +1,17 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
+use std::path::PathBuf;
+
 use futures::FutureExt;
 
 use super::test_builder::TestBuilder;
 use super::types::ExecuteResult;
 
 const FOLDER_SEPARATOR: char = if cfg!(windows) { '\\' } else { '/' };
+
+fn test_data() -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../scripts")
+}
 
 #[tokio::test]
 async fn commands() {
@@ -1480,4 +1486,16 @@ fn no_such_file_error_text() -> &'static str {
   } else {
     "No such file or directory (os error 2)"
   }
+}
+
+#[tokio::test]
+async fn multiline() {
+  let (stdout, _, _) = TestBuilder::new()
+    .command_from_file(&test_data().join("multiline.sh"))
+    .assert_exit_code(0)
+    .ignore_expected_stdout()
+    .run()
+    .await;
+
+  insta::assert_snapshot!(stdout);
 }

--- a/crates/deno_task_shell/src/shell/test_builder.rs
+++ b/crates/deno_task_shell/src/shell/test_builder.rs
@@ -75,6 +75,12 @@ pub struct TestBuilder {
   assertions: Vec<TestAssertion>,
 }
 
+impl Default for TestBuilder {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 impl TestBuilder {
   pub fn new() -> Self {
     let env_vars = std::env::vars()
@@ -144,7 +150,7 @@ impl TestBuilder {
 
   // Run a file as a script
   pub fn command_from_file(&mut self, path: &Path) -> &mut Self {
-    let script = fs::read_to_string(&path).unwrap();
+    let script = fs::read_to_string(path).unwrap();
     self.command(&script);
     self
   }

--- a/crates/shell/src/completion.rs
+++ b/crates/shell/src/completion.rs
@@ -38,7 +38,7 @@ impl Completer for ShellCompleter {
 }
 
 fn extract_word(line: &str, pos: usize) -> (usize, &str) {
-    if line.ends_with(" ") {
+    if line.ends_with(' ') {
         return (pos, "");
     }
     let words: Vec<_> = line[..pos].split_whitespace().collect();

--- a/scripts/multiline.sh
+++ b/scripts/multiline.sh
@@ -1,0 +1,7 @@
+echo "foo \
+    bla"
+
+echo "foo
+    bla"
+
+echo "foo \" bar"


### PR DESCRIPTION
I added a test script that currently also does not parse completely right.

When we have open quotes, we should continue parsing things (and add the `\n` into the string.

When we have a `\` escape, then the `\n` should not be part of the string.

Luckily it's easy to test this against `bash` or `zsh` behavior :)