### PR TITLE
feat: add debug mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 
 [[package]]
+name = "ascii_tree"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6c635b3aa665c649ad1415f1573c85957dfa47690ec27aebe7ec17efe3c643"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +276,7 @@ dependencies = [
  "parking_lot",
  "path-dedot",
  "pest",
+ "pest_ascii_tree",
  "pest_derive",
  "pretty_assertions",
  "serde",
@@ -350,6 +357,12 @@ name = "error-code"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+
+[[package]]
+name = "escape_string"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e867569975c88fdf73833a30bd6e0978aa6ab6bd784b648fcece07450951ba"
 
 [[package]]
 name = "fastrand"
@@ -775,6 +788,18 @@ dependencies = [
  "memchr",
  "thiserror",
  "ucd-trie",
+]
+
+[[package]]
+name = "pest_ascii_tree"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152b393638a9816cd3dedb5aea2fb60ab0b641315aa133cea219c8797e768fc"
+dependencies = [
+ "ascii_tree",
+ "escape_string",
+ "pest",
+ "pest_derive",
 ]
 
 [[package]]

--- a/crates/deno_task_shell/Cargo.toml
+++ b/crates/deno_task_shell/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0.63"
 pest = "2.7.12"
 pest_derive = "2.7.12"
 dirs = "5.0.1"
+pest_ascii_tree = "0.1.0"
 
 [dev-dependencies]
 parking_lot = "0.12.3"

--- a/crates/deno_task_shell/src/parser.rs
+++ b/crates/deno_task_shell/src/parser.rs
@@ -329,6 +329,11 @@ pub enum RedirectOpOutput {
 #[grammar = "grammar.pest"]
 struct ShellParser;
 
+pub fn debug_parse(input: &str) {
+  let parsed = ShellParser::parse(Rule::FILE, input);
+  pest_ascii_tree::print_ascii_tree(parsed);
+}
+
 pub fn parse(input: &str) -> Result<SequentialList> {
   let mut pairs = ShellParser::parse(Rule::FILE, input)?;
 

--- a/crates/shell/src/main.rs
+++ b/crates/shell/src/main.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use anyhow::Context;
 use clap::Parser;
 use completion::ShellCompleter;
+use deno_task_shell::parser::debug_parse;
 use deno_task_shell::{
     execute_sequential_list, AsyncCommandBehavior, ExecuteResult, ShellCommand, ShellPipeReader,
     ShellPipeWriter, ShellState,
@@ -60,6 +61,9 @@ async fn execute(text: &str, state: &mut ShellState) -> anyhow::Result<i32> {
 struct Options {
     #[clap(short, long)]
     file: Option<PathBuf>,
+
+    #[clap(short, long)]
+    debug: bool,
 }
 
 fn init_state() -> ShellState {
@@ -144,6 +148,10 @@ async fn main() -> anyhow::Result<()> {
     if let Some(file) = options.file {
         let script_text = std::fs::read_to_string(&file).unwrap();
         let mut state = init_state();
+        if options.debug {
+            debug_parse(&script_text);
+            return Ok(());
+        }
         execute(&script_text, &mut state).await?;
     } else {
         interactive().await?;


### PR DESCRIPTION
This allows to print the parse tree when doing `cargo r -- -f script.sh -d`