### PR TITLE
Add colors to the prompt

### DIFF
--- a/crates/shell/src/main.rs
+++ b/crates/shell/src/main.rs
@@ -119,8 +119,13 @@ async fn interactive() -> anyhow::Result<()> {
 
             let prompt = cwd
                 .strip_prefix(home_str)
-                .map(|stripped| format!("~{}{git_branch}$ ", stripped.replace('\\', "/")))
-                .unwrap_or_else(|| format!("{}{git_branch}$ ", cwd));
+                .map(|stripped| {
+                    format!(
+                        "\x1b[34m~{}\x1b[31m{git_branch}\x1b[0m$ ",
+                        stripped.replace('\\', "/")
+                    )
+                })
+                .unwrap_or_else(|| format!("\x1b[34m{}\x1b[31m{git_branch}\x1b[0m$ ", cwd));
             rl.readline(&prompt)
         };
 


### PR DESCRIPTION
Fixes https://github.com/prefix-dev/shell/issues/29.

It works, but on Windows the cursor starts at the wrong column.

Linux:

![image](https://github.com/user-attachments/assets/6b40c9dc-64c7-44e2-b4ae-888a8acbf93b)

Windows:

![image](https://github.com/user-attachments/assets/78f977ee-ce39-45a6-b794-14483ad6c040)

@wolfv any idea what might be causing this? I think on Windows it counts the number of characters in the string to offset the column (while it should skip the escape color sequences), but it doesn't do it on linux for some reason.