### PR TITLE
print last line when cat-ting interactively

### DIFF
--- a/crates/deno_task_shell/src/shell/commands/cat.rs
+++ b/crates/deno_task_shell/src/shell/commands/cat.rs
@@ -3,9 +3,11 @@
 use anyhow::Result;
 use futures::future::LocalBoxFuture;
 use std::fs::File;
+use std::io::IsTerminal;
 use std::io::Read;
 
 use crate::shell::types::ExecuteResult;
+use crate::ShellPipeWriter;
 
 use super::args::parse_arg_kinds;
 use super::args::ArgKind;
@@ -55,6 +57,14 @@ fn execute_cat(mut context: ShellCommandContext) -> Result<ExecuteResult> {
             break;
           } else {
             context.stdout.write_all(&buf[..size])?;
+          }
+
+          if let ShellPipeWriter::Stdout = context.stdout {
+            // check if it's interactive
+            if buf[size - 1] != b'\n' && std::io::stdout().is_terminal() {
+              // make sure that we end up on a new line
+              context.stdout.write_all(b"%\n")?;
+            }
           }
         },
         Err(err) => {


### PR DESCRIPTION
If the file does not end with a newline, the last line was swallowed. 

This mimicks what cat on macOS is doing by printing a `%\n` at the end of cat'ting when in interactive mode. On macOS this is a white-on-black percentage sign, which would be a small improvement. 

Not sure if theoretically this should be handled by the shell or cat, though. 
In order to implement this on the shell level we would need to redirect the stdout stream and inspect it.