### PR TITLE
Inital implementation for Tilde expansion

### DIFF
--- a/crates/deno_task_shell/src/grammar.pest
+++ b/crates/deno_task_shell/src/grammar.pest
@@ -7,16 +7,27 @@ COMMENT = _{ "#" ~ (!NEWLINE ~ ANY)* }
 // Basic tokens
 QUOTED_WORD = { DOUBLE_QUOTED | SINGLE_QUOTED }
 
-UNQUOTED_PENDING_WORD = ${ !OPERATOR ~
-    (!(WHITESPACE | NEWLINE) ~ (
+UNQUOTED_PENDING_WORD = ${ 
+    (!(OPERATOR | WHITESPACE | NEWLINE) ~ (
         EXIT_STATUS | 
         UNQUOTED_ESCAPE_CHAR | 
         SUB_COMMAND | 
         ("$" ~ "{" ~ VARIABLE ~ "}" | "$" ~ VARIABLE) | 
+        TILDE_PREFIX |
         UNQUOTED_CHAR | 
         QUOTED_WORD
     )
 )+ }
+
+TILDE_PREFIX = ${
+    "~" ~ (!(OPERATOR | WHITESPACE | NEWLINE | "/") ~ (
+        QUOTED_CHAR 
+    ))*
+}
+
+ASSIGNMENT_TILDE_PREFIX = ${
+    "~" ~ (!(OPERATOR | WHITESPACE | NEWLINE | "/" | ":") ~ ANY)*
+}
 
 FILE_NAME_PENDING_WORD = ${ (!(WHITESPACE | OPERATOR | NEWLINE) ~ (UNQUOTED_ESCAPE_CHAR | ("$" ~ VARIABLE) | UNQUOTED_CHAR | QUOTED_WORD))+ }
 
@@ -41,7 +52,12 @@ DOUBLE_QUOTED = @{ "\"" ~ QUOTED_PENDING_WORD ~ "\"" }
 SINGLE_QUOTED = @{ "'" ~ (!"'" ~ ANY)* ~ "'" }
 
 NAME = ${ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
-ASSIGNMENT_WORD = { NAME ~ "=" ~ UNQUOTED_PENDING_WORD? }
+ASSIGNMENT_WORD = { NAME ~ "=" ~ ASSIGNMENT_VALUE? }
+ASSIGNMENT_VALUE = ${ 
+    ASSIGNMENT_TILDE_PREFIX ~ 
+    ((":" ~ ASSIGNMENT_TILDE_PREFIX) | (!":" ~ UNQUOTED_PENDING_WORD))* |
+    UNQUOTED_PENDING_WORD
+}
 IO_NUMBER = @{ ASCII_DIGIT+ }
 
 // Special tokens
@@ -59,6 +75,7 @@ DLESSDASH = { "<<-" }
 CLOBBER = { ">|" }
 AMPERSAND = { "&" }
 EXIT_STATUS = ${ "$?" }
+TILDE = ${ "~" }
 
 
 // Operators

--- a/crates/deno_task_shell/src/parser.rs
+++ b/crates/deno_task_shell/src/parser.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Result, Context};
 use pest::iterators::Pair;
 use pest::Parser;
 use pest_derive::Parser;
@@ -215,6 +215,23 @@ impl EnvVar {
 }
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
+#[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct TildePrefix {
+  pub user: Option<String>,
+}
+
+impl TildePrefix {
+  pub fn only_tilde(self) -> bool {
+    self.user.is_none()
+  }
+
+  pub fn new(user: Option<String>) -> Self {
+    TildePrefix { user }
+  }
+}
+
+#[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Word(Vec<WordPart>);
 
@@ -261,6 +278,8 @@ pub enum WordPart {
   Command(SequentialList),
   /// Quoted string (ex. `"hello"` or `'test'`)
   Quoted(Vec<WordPart>),
+  /// Tilde prefix (ex. `~user/path`)
+  Tilde(TildePrefix),
 }
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
@@ -730,6 +749,10 @@ fn parse_word(pair: Pair<Rule>) -> Result<Word> {
             let quoted = parse_quoted_word(part)?;
             parts.push(quoted);
           }
+          Rule::TILDE_PREFIX => {
+            let tilde_prefix = parse_tilde_prefix(part)?;
+            parts.push(tilde_prefix);
+          }
           _ => {
             return Err(anyhow::anyhow!(
               "Unexpected rule in UNQUOTED_PENDING_WORD: {:?}",
@@ -793,6 +816,17 @@ fn parse_word(pair: Pair<Rule>) -> Result<Word> {
   } else {
     Ok(Word::new(parts))
   }
+}
+
+fn parse_tilde_prefix(pair: Pair<Rule>) -> Result<WordPart> {
+  let tilde_prefix_str = pair.as_str();
+  let user = if tilde_prefix_str.len() > 1 {
+    Some(tilde_prefix_str[1..].to_string())
+  } else {
+    None
+  };
+  let tilde_prefix = TildePrefix::new(user);
+  Ok(WordPart::Tilde(tilde_prefix))
 }
 
 fn parse_quoted_word(pair: Pair<Rule>) -> Result<WordPart> {
@@ -863,7 +897,7 @@ fn parse_env_var(pair: Pair<Rule>) -> Result<EnvVar> {
 
   // Get the value of the environment variable
   let word_value = if let Some(value) = parts.next() {
-    parse_word(value)?
+    parse_assignment_value(value).context("Failed to parse assignment value")?
   } else {
     Word::new_empty()
   };
@@ -872,6 +906,31 @@ fn parse_env_var(pair: Pair<Rule>) -> Result<EnvVar> {
     name,
     value: word_value,
   })
+}
+
+fn parse_assignment_value(pair: Pair<Rule>) -> Result<Word> {
+    let mut parts = Vec::new();
+    
+    for part in pair.into_inner() {
+        match part.as_rule() {
+            Rule::ASSIGNMENT_TILDE_PREFIX => {
+                let tilde_prefix = parse_tilde_prefix(part).context("Failed to parse tilde prefix")?;
+                parts.push(tilde_prefix);
+            }
+            Rule::UNQUOTED_PENDING_WORD => {
+                let word_parts = parse_word(part)?;
+                parts.extend(word_parts.into_parts());
+            }
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Unexpected rule in assignment value: {:?}",
+                    part.as_rule()
+                ))
+            }
+        }
+    }
+
+    Ok(Word::new(parts))
 }
 
 fn parse_io_redirect(pair: Pair<Rule>) -> Result<Redirect> {

--- a/crates/deno_task_shell/src/parser.rs
+++ b/crates/deno_task_shell/src/parser.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
-use anyhow::{anyhow, Result, Context};
+use anyhow::{anyhow, Context, Result};
 use pest::iterators::Pair;
 use pest::Parser;
 use pest_derive::Parser;
@@ -909,28 +909,29 @@ fn parse_env_var(pair: Pair<Rule>) -> Result<EnvVar> {
 }
 
 fn parse_assignment_value(pair: Pair<Rule>) -> Result<Word> {
-    let mut parts = Vec::new();
-    
-    for part in pair.into_inner() {
-        match part.as_rule() {
-            Rule::ASSIGNMENT_TILDE_PREFIX => {
-                let tilde_prefix = parse_tilde_prefix(part).context("Failed to parse tilde prefix")?;
-                parts.push(tilde_prefix);
-            }
-            Rule::UNQUOTED_PENDING_WORD => {
-                let word_parts = parse_word(part)?;
-                parts.extend(word_parts.into_parts());
-            }
-            _ => {
-                return Err(anyhow::anyhow!(
-                    "Unexpected rule in assignment value: {:?}",
-                    part.as_rule()
-                ))
-            }
-        }
-    }
+  let mut parts = Vec::new();
 
-    Ok(Word::new(parts))
+  for part in pair.into_inner() {
+    match part.as_rule() {
+      Rule::ASSIGNMENT_TILDE_PREFIX => {
+        let tilde_prefix =
+          parse_tilde_prefix(part).context("Failed to parse tilde prefix")?;
+        parts.push(tilde_prefix);
+      }
+      Rule::UNQUOTED_PENDING_WORD => {
+        let word_parts = parse_word(part)?;
+        parts.extend(word_parts.into_parts());
+      }
+      _ => {
+        return Err(anyhow::anyhow!(
+          "Unexpected rule in assignment value: {:?}",
+          part.as_rule()
+        ))
+      }
+    }
+  }
+
+  Ok(Word::new(parts))
 }
 
 fn parse_io_redirect(pair: Pair<Rule>) -> Result<Redirect> {

--- a/crates/deno_task_shell/src/shell/execute.rs
+++ b/crates/deno_task_shell/src/shell/execute.rs
@@ -904,10 +904,13 @@ fn evaluate_word_parts(
 
             current_text.push(TextPart::Quoted(text));
             continue;
-          },
+          }
           WordPart::Tilde(tilde_prefix) => {
             if tilde_prefix.only_tilde() {
-              let home_str = dirs::home_dir().context("Failed to get home directory")?.display().to_string();
+              let home_str = dirs::home_dir()
+                .context("Failed to get home directory")?
+                .display()
+                .to_string();
               current_text.push(TextPart::Text(home_str));
             } else {
               todo!("tilde expansion with user name is not supported");

--- a/crates/deno_task_shell/src/shell/execute.rs
+++ b/crates/deno_task_shell/src/shell/execute.rs
@@ -895,6 +895,10 @@ fn evaluate_word_parts(
 
             current_text.push(TextPart::Quoted(text));
             continue;
+          },
+          WordPart::Tilde(tilde_prefix) => {
+            current_text.push(TextPart::Text(tilde_prefix));
+            continue;
           }
         };
 

--- a/scripts/tilde_expansion.sh
+++ b/scripts/tilde_expansion.sh
@@ -1,0 +1,7 @@
+ls ~/Desktop
+
+echo ~$var
+
+echo ~\/bin
+
+echo ~parsabahraminejad/Desktop


### PR DESCRIPTION
As an alternative to #49. The tilde_prefix is being parsed at parser level which then results in an AST Node being created containing the user. (If the ~ should be expanded to $HOME, then the user is empty) 
And then `~` is expanded later.