### PR TITLE
feat: implement `source`

### DIFF
--- a/crates/shell/src/commands.rs
+++ b/crates/shell/src/commands.rs
@@ -79,6 +79,7 @@ impl ShellCommand for SourceCommand {
             // TODO turn into execute result
             let content = fs::read_to_string(script_file).unwrap();
             let mut state = context.state.clone();
+
             async move {
                 execute::execute(&content, &mut state).await.unwrap();
                 ExecuteResult::from_exit_code(0)

--- a/crates/shell/src/commands.rs
+++ b/crates/shell/src/commands.rs
@@ -78,14 +78,10 @@ impl ShellCommand for SourceCommand {
         if script_file.exists() {
             // TODO turn into execute result
             let content = fs::read_to_string(script_file).unwrap();
-            let mut state = context.state.clone();
-
-            async move {
-                execute::execute(&content, &mut state).await.unwrap();
-                ExecuteResult::from_exit_code(0)
-            }.boxed_local()
+            let state = context.state.clone();
+            async move { execute::execute_inner(&content, state).await.unwrap() }.boxed_local()
+        } else {
+            Box::pin(futures::future::ready(ExecuteResult::from_exit_code(1)))
         }
-
-        Box::pin(futures::future::ready(ExecuteResult::from_exit_code(0)))
     }
 }

--- a/crates/shell/src/execute.rs
+++ b/crates/shell/src/execute.rs
@@ -1,0 +1,39 @@
+use anyhow::Context;
+use deno_task_shell::{
+    execute_sequential_list, AsyncCommandBehavior, ExecuteResult, ShellPipeReader, ShellPipeWriter,
+    ShellState,
+};
+
+pub async fn execute(text: &str, state: &mut ShellState) -> anyhow::Result<i32> {
+    let list = deno_task_shell::parser::parse(text);
+
+    let mut stderr = ShellPipeWriter::stderr();
+    let stdout = ShellPipeWriter::stdout();
+    let stdin = ShellPipeReader::stdin();
+
+    if let Err(e) = list {
+        let _ = stderr.write_line(&format!("Syntax error: {}", e));
+        return Ok(1);
+    }
+
+    // spawn a sequential list and pipe its output to the environment
+    let result = execute_sequential_list(
+        list.unwrap(),
+        state.clone(),
+        stdin,
+        stdout,
+        stderr,
+        AsyncCommandBehavior::Wait,
+    )
+    .await;
+
+    match result {
+        ExecuteResult::Continue(exit_code, changes, _) => {
+            // set CWD to the last command's CWD
+            state.apply_changes(&changes);
+            std::env::set_current_dir(state.cwd()).context("Failed to set CWD")?;
+            Ok(exit_code)
+        }
+        ExecuteResult::Exit(_, _) => Ok(0),
+    }
+}


### PR DESCRIPTION
Fixes #94.

I am not sure about the exact semantics. Currently, everything that is modified in the sourced' script is also going to be modified in the parent script.