### PR TITLE
Switch to miette for error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "android-tzdata"
@@ -110,17 +110,26 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
 ]
 
 [[package]]
@@ -272,10 +281,11 @@ dependencies = [
  "dirs",
  "futures",
  "glob",
+ "miette",
  "os_pipe",
  "parking_lot",
  "path-dedot",
- "pest",
+ "pest 2.7.12 (git+https://github.com/pest-parser/pest.git?branch=master)",
  "pest_ascii_tree",
  "pest_derive",
  "pretty_assertions",
@@ -354,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.2.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "escape_string"
@@ -493,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "glob"
@@ -557,6 +567,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -642,12 +658,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.7.4"
+name = "miette"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
 dependencies = [
- "adler",
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -748,6 +795,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,14 +844,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest"
+version = "2.7.12"
+source = "git+https://github.com/pest-parser/pest.git?branch=master#65e5b2b754a4d9bb9b231ab61ef0af437b556fbe"
+dependencies = [
+ "memchr",
+ "miette",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
 name = "pest_ascii_tree"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152b393638a9816cd3dedb5aea2fb60ab0b641315aa133cea219c8797e768fc"
+source = "git+https://github.com/prsabahrami/pest_ascii_tree.git?branch=master#65ef51a888730598336b0628c3e42bc5ec2f358b"
 dependencies = [
  "ascii_tree",
  "escape_string",
- "pest",
+ "pest 2.7.12 (git+https://github.com/pest-parser/pest.git?branch=master)",
  "pest_derive",
 ]
 
@@ -808,7 +873,7 @@ version = "2.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
 dependencies = [
- "pest",
+ "pest 2.7.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_generator",
 ]
 
@@ -818,7 +883,7 @@ version = "2.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
 dependencies = [
- "pest",
+ "pest 2.7.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_meta",
  "proc-macro2",
  "quote",
@@ -832,7 +897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
 dependencies = [
  "once_cell",
- "pest",
+ "pest 2.7.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2",
 ]
 
@@ -1059,10 +1124,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "supports-color"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8775305acf21c96926c900ad056abeef436701108518cf890020387236ac5a77"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
@@ -1096,6 +1188,17 @@ checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1172,9 +1275,15 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"

--- a/crates/deno_task_shell/Cargo.toml
+++ b/crates/deno_task_shell/Cargo.toml
@@ -24,10 +24,11 @@ tokio-util = { version = "0.7.12", optional = true }
 os_pipe = { version = "1.2.1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror = "1.0.63"
-pest = "2.7.12"
+pest = { git = "https://github.com/pest-parser/pest.git", branch = "master", features = ["miette-error"] }
 pest_derive = "2.7.12"
 dirs = "5.0.1"
-pest_ascii_tree = "0.1.0"
+pest_ascii_tree = { git = "https://github.com/prsabahrami/pest_ascii_tree.git", branch = "master" }
+miette = "7.2.0"
 
 [dev-dependencies]
 parking_lot = "0.12.3"

--- a/crates/deno_task_shell/src/parser.rs
+++ b/crates/deno_task_shell/src/parser.rs
@@ -371,8 +371,9 @@ pub fn debug_parse(input: &str) {
 }
 
 pub fn parse(input: &str) -> Result<SequentialList> {
-  let mut pairs = ShellParser::parse(Rule::FILE, input)
-    .map_err(|e| miette::Error::new(e.into_miette()).context("Failed to parse input"))?;
+  let mut pairs = ShellParser::parse(Rule::FILE, input).map_err(|e| {
+    miette::Error::new(e.into_miette()).context("Failed to parse input")
+  })?;
 
   parse_file(pairs.next().unwrap())
 }
@@ -393,7 +394,10 @@ fn parse_complete_command(pair: Pair<Rule>) -> Result<SequentialList> {
         break;
       }
       _ => {
-        return Err(miette!("Unexpected rule in complete_command: {:?}", command.as_rule()));
+        return Err(miette!(
+          "Unexpected rule in complete_command: {:?}",
+          command.as_rule()
+        ));
       }
     }
   }
@@ -444,7 +448,10 @@ fn parse_compound_list(
         }
       }
       _ => {
-        return Err(miette!("Unexpected rule in compound_list: {:?}", item.as_rule()));
+        return Err(miette!(
+          "Unexpected rule in compound_list: {:?}",
+          item.as_rule()
+        ));
       }
     }
   }
@@ -490,7 +497,9 @@ fn parse_and_or(pair: Pair<Rule>) -> Result<Sequence> {
   match items.next() {
     Some(next_item) => {
       if next_item.as_rule() == Rule::ASSIGNMENT_WORD {
-        return Err(miette!("Multiple assignment words before && or || is not supported yet"));
+        return Err(miette!(
+          "Multiple assignment words before && or || is not supported yet"
+        ));
       } else {
         let op = match next_item.as_str() {
           "&&" => BooleanListOperator::And,
@@ -545,9 +554,9 @@ fn parse_pipeline(pair: Pair<Rule>) -> Result<Sequence> {
       ));
     }
     // Get the actual pipe sequence after whitespace
-    let pipe_sequence = inner.next().ok_or_else(|| {
-      miette!("Expected pipe sequence after negation")
-    })?;
+    let pipe_sequence = inner
+      .next()
+      .ok_or_else(|| miette!("Expected pipe sequence after negation"))?;
     (true, pipe_sequence)
   } else {
     // If it's not Bang, this element itself is the pipe_sequence
@@ -566,9 +575,9 @@ fn parse_pipe_sequence(pair: Pair<Rule>) -> Result<PipelineInner> {
   let mut inner = pair.into_inner();
 
   // Parse the first command
-  let first_command = inner.next().ok_or_else(|| {
-    miette!("Expected at least one command in pipe sequence")
-  })?;
+  let first_command = inner
+    .next()
+    .ok_or_else(|| miette!("Expected at least one command in pipe sequence"))?;
   let current = parse_command(first_command)?;
 
   // Check if there's a pipe operator
@@ -586,9 +595,9 @@ fn parse_pipe_sequence(pair: Pair<Rule>) -> Result<PipelineInner> {
       };
 
       // Parse the rest of the pipe sequence
-      let next_sequence = inner.next().ok_or_else(|| {
-        miette!("Expected command after pipe operator")
-      })?;
+      let next_sequence = inner
+        .next()
+        .ok_or_else(|| miette!("Expected command after pipe operator"))?;
       let next = parse_pipe_sequence(next_sequence)?;
 
       Ok(PipelineInner::PipeSequence(Box::new(PipeSequence {
@@ -609,10 +618,7 @@ fn parse_command(pair: Pair<Rule>) -> Result<Command> {
     Rule::function_definition => {
       Err(miette!("Function definitions are not supported yet"))
     }
-    _ => Err(miette!(
-      "Unexpected rule in command: {:?}",
-      inner.as_rule()
-    )),
+    _ => Err(miette!("Unexpected rule in command: {:?}", inner.as_rule())),
   }
 }
 
@@ -677,13 +683,21 @@ fn parse_simple_command(pair: Pair<Rule>) -> Result<Command> {
 fn parse_compound_command(pair: Pair<Rule>) -> Result<Command> {
   let inner = pair.into_inner().next().unwrap();
   match inner.as_rule() {
-    Rule::brace_group => Err(miette!("Unsupported compound command brace_group")),
+    Rule::brace_group => {
+      Err(miette!("Unsupported compound command brace_group"))
+    }
     Rule::subshell => parse_subshell(inner),
     Rule::for_clause => Err(miette!("Unsupported compound command for_clause")),
-    Rule::case_clause => Err(miette!("Unsupported compound command case_clause")),
+    Rule::case_clause => {
+      Err(miette!("Unsupported compound command case_clause"))
+    }
     Rule::if_clause => Err(miette!("Unsupported compound command if_clause")),
-    Rule::while_clause => Err(miette!("Unsupported compound command while_clause")),
-    Rule::until_clause => Err(miette!("Unsupported compound command until_clause")),
+    Rule::while_clause => {
+      Err(miette!("Unsupported compound command while_clause"))
+    }
+    Rule::until_clause => {
+      Err(miette!("Unsupported compound command until_clause"))
+    }
     _ => Err(miette!(
       "Unexpected rule in compound_command: {:?}",
       inner.as_rule()
@@ -815,10 +829,7 @@ fn parse_word(pair: Pair<Rule>) -> Result<Word> {
       }
     }
     _ => {
-      return Err(miette!(
-        "Unexpected rule in word: {:?}",
-        pair.as_rule()
-      ));
+      return Err(miette!("Unexpected rule in word: {:?}", pair.as_rule()));
     }
   }
 

--- a/crates/deno_task_shell/src/parser.rs
+++ b/crates/deno_task_shell/src/parser.rs
@@ -1,23 +1,26 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
-use anyhow::{anyhow, Context, Result};
+use miette::{miette, Context, Result};
 use pest::iterators::Pair;
 use pest::Parser;
 use pest_derive::Parser;
+use thiserror::Error;
 
 // Shell grammar rules this is loosely based on:
 // https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_10_02
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Invalid sequential list")]
 pub struct SequentialList {
   pub items: Vec<SequentialListItem>,
 }
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Invalid sequential list item")]
 pub struct SequentialListItem {
   pub is_async: bool,
   pub sequence: Sequence,
@@ -28,21 +31,21 @@ pub struct SequentialListItem {
   feature = "serialization",
   serde(rename_all = "camelCase", tag = "kind")
 )]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum Sequence {
-  /// `MY_VAR=5`
+  #[error("Invalid shell variable")]
   ShellVar(EnvVar),
-  /// `cmd_name <args...>`, `cmd1 | cmd2`
+  #[error("Invalid pipeline")]
   Pipeline(Pipeline),
-  /// `cmd1 && cmd2 || cmd3`
+  #[error("Invalid boolean list")]
   BooleanList(Box<BooleanList>),
 }
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Invalid pipeline")]
 pub struct Pipeline {
-  /// `! pipeline`
   pub negated: bool,
   pub inner: PipelineInner,
 }
@@ -58,11 +61,11 @@ impl From<Pipeline> for Sequence {
   feature = "serialization",
   serde(rename_all = "camelCase", tag = "kind")
 )]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum PipelineInner {
-  /// Ex. `cmd_name <args...>`
+  #[error("Invalid command")]
   Command(Command),
-  /// `cmd1 | cmd2`
+  #[error("Invalid pipe sequence")]
   PipeSequence(Box<PipeSequence>),
 }
 
@@ -74,11 +77,11 @@ impl From<PipeSequence> for PipelineInner {
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Error)]
 pub enum BooleanListOperator {
-  // &&
+  #[error("AND operator")]
   And,
-  // ||
+  #[error("OR operator")]
   Or,
 }
 
@@ -98,7 +101,8 @@ impl BooleanListOperator {
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Invalid boolean list")]
 pub struct BooleanList {
   pub current: Sequence,
   pub op: BooleanListOperator,
@@ -107,17 +111,18 @@ pub struct BooleanList {
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Error)]
 pub enum PipeSequenceOperator {
-  // |
+  #[error("Stdout pipe operator")]
   Stdout,
-  // |&
+  #[error("Stdout and stderr pipe operator")]
   StdoutStderr,
 }
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Invalid pipe sequence")]
 pub struct PipeSequence {
   pub current: Command,
   pub op: PipeSequenceOperator,
@@ -135,7 +140,8 @@ impl From<PipeSequence> for Sequence {
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Invalid command")]
 pub struct Command {
   pub inner: CommandInner,
   pub redirect: Option<Redirect>,
@@ -146,11 +152,11 @@ pub struct Command {
   feature = "serialization",
   serde(rename_all = "camelCase", tag = "kind")
 )]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum CommandInner {
-  /// `cmd_name <args...>`
+  #[error("Invalid simple command")]
   Simple(SimpleCommand),
-  /// `(list)`
+  #[error("Invalid subshell")]
   Subshell(Box<SequentialList>),
 }
 
@@ -166,7 +172,8 @@ impl From<Command> for Sequence {
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Invalid simple command")]
 pub struct SimpleCommand {
   pub env_vars: Vec<EnvVar>,
   pub args: Vec<Word>,
@@ -202,7 +209,8 @@ impl From<SimpleCommand> for Sequence {
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Error)]
+#[error("Invalid environment variable")]
 pub struct EnvVar {
   pub name: String,
   pub value: Word,
@@ -216,7 +224,8 @@ impl EnvVar {
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Error)]
+#[error("Invalid tilde prefix")]
 pub struct TildePrefix {
   pub user: Option<String>,
 }
@@ -232,7 +241,8 @@ impl TildePrefix {
 }
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Error)]
+#[error("Invalid word")]
 pub struct Word(Vec<WordPart>);
 
 impl Word {
@@ -268,19 +278,19 @@ impl Word {
   feature = "serialization",
   serde(rename_all = "camelCase", tag = "kind", content = "value")
 )]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Error)]
 pub enum WordPart {
-  /// Text in the string (ex. `some text`)
+  #[error("Invalid text")]
   Text(String),
-  /// Variable substitution (ex. `$MY_VAR`)
+  #[error("Invalid variable")]
   Variable(String),
-  /// Command substitution (ex. `$(command)`)
+  #[error("Invalid command")]
   Command(SequentialList),
-  /// Quoted string (ex. `"hello"` or `'test'`)
+  #[error("Invalid quoted string")]
   Quoted(Vec<WordPart>),
-  /// Tilde prefix (ex. `~user/path` or `~/bin`)
+  #[error("Invalid tilde prefix")]
   Tilde(TildePrefix),
-  /// Exit status of the last command (ex. `$?`)
+  #[error("Invalid exit status")]
   ExitStatus,
 }
 
@@ -289,15 +299,18 @@ pub enum WordPart {
   feature = "serialization",
   serde(rename_all = "camelCase", tag = "kind", content = "fd")
 )]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum RedirectFd {
+  #[error("Invalid file descriptor")]
   Fd(u32),
+  #[error("Invalid stdout and stderr redirect")]
   StdoutStderr,
 }
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Invalid redirect")]
 pub struct Redirect {
   pub maybe_fd: Option<RedirectFd>,
   pub op: RedirectOp,
@@ -309,11 +322,11 @@ pub struct Redirect {
   feature = "serialization",
   serde(rename_all = "camelCase", tag = "kind", content = "value")
 )]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum IoFile {
-  /// Filename to redirect to/from (ex. `file.txt`` in `cmd < file.txt`)
+  #[error("Invalid word")]
   Word(Word),
-  /// File descriptor to redirect to/from (ex. `2` in `cmd >&2`)
+  #[error("Invalid file descriptor")]
   Fd(u32),
 }
 
@@ -322,27 +335,29 @@ pub enum IoFile {
   feature = "serialization",
   serde(rename_all = "camelCase", tag = "kind", content = "value")
 )]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum RedirectOp {
+  #[error("Invalid input redirect")]
   Input(RedirectOpInput),
+  #[error("Invalid output redirect")]
   Output(RedirectOpOutput),
 }
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum RedirectOpInput {
-  /// <
+  #[error("Invalid input redirect")]
   Redirect,
 }
 
 #[cfg_attr(feature = "serialization", derive(serde::Serialize))]
 #[cfg_attr(feature = "serialization", serde(rename_all = "camelCase"))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum RedirectOpOutput {
-  /// >
+  #[error("Invalid overwrite redirect")]
   Overwrite,
-  /// >>
+  #[error("Invalid append redirect")]
   Append,
 }
 
@@ -356,7 +371,8 @@ pub fn debug_parse(input: &str) {
 }
 
 pub fn parse(input: &str) -> Result<SequentialList> {
-  let mut pairs = ShellParser::parse(Rule::FILE, input)?;
+  let mut pairs = ShellParser::parse(Rule::FILE, input)
+    .map_err(|e| miette::Error::new(e.into_miette()).context("Failed to parse input"))?;
 
   parse_file(pairs.next().unwrap())
 }
@@ -377,10 +393,7 @@ fn parse_complete_command(pair: Pair<Rule>) -> Result<SequentialList> {
         break;
       }
       _ => {
-        return Err(anyhow::anyhow!(
-          "Unexpected rule in complete_command: {:?}",
-          command.as_rule()
-        ));
+        return Err(miette!("Unexpected rule in complete_command: {:?}", command.as_rule()));
       }
     }
   }
@@ -406,10 +419,7 @@ fn parse_list(
         }
       }
       _ => {
-        return Err(anyhow::anyhow!(
-          "Unexpected rule in list: {:?}",
-          item.as_rule()
-        ));
+        return Err(miette!("Unexpected rule in list: {:?}", item.as_rule()));
       }
     }
   }
@@ -434,7 +444,7 @@ fn parse_compound_list(
         }
       }
       _ => {
-        anyhow::bail!("Unexpected rule in compound_list: {:?}", item.as_rule());
+        return Err(miette!("Unexpected rule in compound_list: {:?}", item.as_rule()));
       }
     }
   }
@@ -460,10 +470,7 @@ fn parse_term(
         }
       }
       _ => {
-        return Err(anyhow::anyhow!(
-          "Unexpected rule in term: {:?}",
-          item.as_rule()
-        ));
+        return Err(miette!("Unexpected rule in term: {:?}", item.as_rule()));
       }
     }
   }
@@ -483,9 +490,7 @@ fn parse_and_or(pair: Pair<Rule>) -> Result<Sequence> {
   match items.next() {
     Some(next_item) => {
       if next_item.as_rule() == Rule::ASSIGNMENT_WORD {
-        anyhow::bail!(
-          "Multiple assignment words before && or || is not supported yet"
-        );
+        return Err(miette!("Multiple assignment words before && or || is not supported yet"));
       } else {
         let op = match next_item.as_str() {
           "&&" => BooleanListOperator::And,
@@ -511,12 +516,12 @@ fn parse_shell_var(pair: Pair<Rule>) -> Result<Sequence> {
   let mut inner = pair.into_inner();
   let name = inner
     .next()
-    .ok_or_else(|| anyhow::anyhow!("Expected variable name"))?
+    .ok_or_else(|| miette!("Expected variable name"))?
     .as_str()
     .to_string();
   let value = inner
     .next()
-    .ok_or_else(|| anyhow::anyhow!("Expected variable value"))?;
+    .ok_or_else(|| miette!("Expected variable value"))?;
   let value = parse_assignment_value(value)?;
   Ok(Sequence::ShellVar(EnvVar { name, value }))
 }
@@ -528,20 +533,20 @@ fn parse_pipeline(pair: Pair<Rule>) -> Result<Sequence> {
   // Check if the first element is Bang (negation)
   let first = inner
     .next()
-    .ok_or_else(|| anyhow::anyhow!("Expected pipeline content"))?;
+    .ok_or_else(|| miette!("Expected pipeline content"))?;
   let (negated, pipe_sequence) = if first.as_rule() == Rule::Bang {
     // If it's Bang, check for whitespace
     if pipeline_str.len() > 1
       && !pipeline_str[1..2].chars().next().unwrap().is_whitespace()
     {
-      anyhow::bail!(
+      return Err(miette!(
         "Perhaps you meant to add a space after the exclamation point to negate the command?\n  ! {}", 
         pipeline_str
-      );
+      ));
     }
     // Get the actual pipe sequence after whitespace
     let pipe_sequence = inner.next().ok_or_else(|| {
-      anyhow::anyhow!("Expected pipe sequence after negation")
+      miette!("Expected pipe sequence after negation")
     })?;
     (true, pipe_sequence)
   } else {
@@ -562,7 +567,7 @@ fn parse_pipe_sequence(pair: Pair<Rule>) -> Result<PipelineInner> {
 
   // Parse the first command
   let first_command = inner.next().ok_or_else(|| {
-    anyhow::anyhow!("Expected at least one command in pipe sequence")
+    miette!("Expected at least one command in pipe sequence")
   })?;
   let current = parse_command(first_command)?;
 
@@ -573,16 +578,16 @@ fn parse_pipe_sequence(pair: Pair<Rule>) -> Result<PipelineInner> {
         Rule::Stdout => PipeSequenceOperator::Stdout,
         Rule::StdoutStderr => PipeSequenceOperator::StdoutStderr,
         _ => {
-          return Err(anyhow::anyhow!(
+          return Err(miette!(
             "Expected pipe operator, found {:?}",
             pipe_op.as_rule()
-          ))
+          ));
         }
       };
 
       // Parse the rest of the pipe sequence
       let next_sequence = inner.next().ok_or_else(|| {
-        anyhow::anyhow!("Expected command after pipe operator")
+        miette!("Expected command after pipe operator")
       })?;
       let next = parse_pipe_sequence(next_sequence)?;
 
@@ -602,9 +607,9 @@ fn parse_command(pair: Pair<Rule>) -> Result<Command> {
     Rule::simple_command => parse_simple_command(inner),
     Rule::compound_command => parse_compound_command(inner),
     Rule::function_definition => {
-      todo!("function definitions are not supported yet")
+      Err(miette!("Function definitions are not supported yet"))
     }
-    _ => Err(anyhow::anyhow!(
+    _ => Err(miette!(
       "Unexpected rule in command: {:?}",
       inner.as_rule()
     )),
@@ -622,12 +627,12 @@ fn parse_simple_command(pair: Pair<Rule>) -> Result<Command> {
         for prefix in item.into_inner() {
           match prefix.as_rule() {
             Rule::ASSIGNMENT_WORD => env_vars.push(parse_env_var(prefix)?),
-            Rule::io_redirect => todo!("io_redirect as prefix"),
+            Rule::io_redirect => return Err(miette!("io_redirect as prefix")),
             _ => {
-              return Err(anyhow::anyhow!(
+              return Err(miette!(
                 "Unexpected rule in cmd_prefix: {:?}",
                 prefix.as_rule()
-              ))
+              ));
             }
           }
         }
@@ -646,19 +651,19 @@ fn parse_simple_command(pair: Pair<Rule>) -> Result<Command> {
               args.push(Word::new(vec![parse_quoted_word(suffix)?]))
             }
             _ => {
-              return Err(anyhow::anyhow!(
+              return Err(miette!(
                 "Unexpected rule in cmd_suffix: {:?}",
                 suffix.as_rule()
-              ))
+              ));
             }
           }
         }
       }
       _ => {
-        return Err(anyhow::anyhow!(
+        return Err(miette!(
           "Unexpected rule in simple_command: {:?}",
           item.as_rule()
-        ))
+        ));
       }
     }
   }
@@ -672,14 +677,14 @@ fn parse_simple_command(pair: Pair<Rule>) -> Result<Command> {
 fn parse_compound_command(pair: Pair<Rule>) -> Result<Command> {
   let inner = pair.into_inner().next().unwrap();
   match inner.as_rule() {
-    Rule::brace_group => todo!("brace_group"),
+    Rule::brace_group => Err(miette!("Unsupported compound command brace_group")),
     Rule::subshell => parse_subshell(inner),
-    Rule::for_clause => todo!("for_clause"),
-    Rule::case_clause => todo!("case_clause"),
-    Rule::if_clause => todo!("if_clause"),
-    Rule::while_clause => todo!("while_clause"),
-    Rule::until_clause => todo!("until_clause"),
-    _ => Err(anyhow::anyhow!(
+    Rule::for_clause => Err(miette!("Unsupported compound command for_clause")),
+    Rule::case_clause => Err(miette!("Unsupported compound command case_clause")),
+    Rule::if_clause => Err(miette!("Unsupported compound command if_clause")),
+    Rule::while_clause => Err(miette!("Unsupported compound command while_clause")),
+    Rule::until_clause => Err(miette!("Unsupported compound command until_clause")),
+    _ => Err(miette!(
       "Unexpected rule in compound_command: {:?}",
       inner.as_rule()
     )),
@@ -695,7 +700,7 @@ fn parse_subshell(pair: Pair<Rule>) -> Result<Command> {
       redirect: None,
     })
   } else {
-    Err(anyhow::anyhow!("Unexpected end of input in subshell"))
+    Err(miette!("Unexpected end of input in subshell"))
   }
 }
 
@@ -756,10 +761,10 @@ fn parse_word(pair: Pair<Rule>) -> Result<Word> {
             parts.push(tilde_prefix);
           }
           _ => {
-            return Err(anyhow::anyhow!(
+            return Err(miette!(
               "Unexpected rule in UNQUOTED_PENDING_WORD: {:?}",
               part.as_rule()
-            ))
+            ));
           }
         }
       }
@@ -801,19 +806,19 @@ fn parse_word(pair: Pair<Rule>) -> Result<Word> {
             parts.push(tilde_prefix);
           }
           _ => {
-            return Err(anyhow::anyhow!(
+            return Err(miette!(
               "Unexpected rule in FILE_NAME_PENDING_WORD: {:?}",
               part.as_rule()
-            ))
+            ));
           }
         }
       }
     }
     _ => {
-      return Err(anyhow::anyhow!(
+      return Err(miette!(
         "Unexpected rule in word: {:?}",
         pair.as_rule()
-      ))
+      ));
     }
   }
 
@@ -868,10 +873,10 @@ fn parse_quoted_word(pair: Pair<Rule>) -> Result<WordPart> {
             }
           }
           _ => {
-            return Err(anyhow::anyhow!(
+            return Err(miette!(
               "Unexpected rule in DOUBLE_QUOTED: {:?}",
               part.as_rule()
-            ))
+            ));
           }
         }
       }
@@ -884,7 +889,7 @@ fn parse_quoted_word(pair: Pair<Rule>) -> Result<WordPart> {
         trimmed_str.to_string(),
       )]))
     }
-    _ => Err(anyhow::anyhow!(
+    _ => Err(miette!(
       "Unexpected rule in QUOTED_WORD: {:?}",
       inner.as_rule()
     )),
@@ -897,7 +902,7 @@ fn parse_env_var(pair: Pair<Rule>) -> Result<EnvVar> {
   // Get the name of the environment variable
   let name = parts
     .next()
-    .ok_or_else(|| anyhow!("Expected variable name"))?
+    .ok_or_else(|| miette!("Expected variable name"))?
     .as_str()
     .to_string();
 
@@ -929,10 +934,10 @@ fn parse_assignment_value(pair: Pair<Rule>) -> Result<Word> {
         parts.extend(word_parts.into_parts());
       }
       _ => {
-        return Err(anyhow::anyhow!(
+        return Err(miette!(
           "Unexpected rule in assignment value: {:?}",
           part.as_rule()
-        ))
+        ));
       }
     }
   }
@@ -948,17 +953,17 @@ fn parse_io_redirect(pair: Pair<Rule>) -> Result<Redirect> {
     Some(p) if p.as_rule() == Rule::IO_NUMBER => (
       Some(RedirectFd::Fd(p.as_str().parse::<u32>().unwrap())),
       inner.next().ok_or_else(|| {
-        anyhow!("Expected redirection operator after IO number")
+        miette!("Expected redirection operator after IO number")
       })?,
     ),
     Some(p) if p.as_rule() == Rule::AMPERSAND => (
       Some(RedirectFd::StdoutStderr),
       inner
         .next()
-        .ok_or_else(|| anyhow!("Expected redirection operator after &"))?,
+        .ok_or_else(|| miette!("Expected redirection operator after &"))?,
     ),
     Some(p) => (None, p),
-    None => return Err(anyhow!("Unexpected end of input in io_redirect")),
+    None => return Err(miette!("Unexpected end of input in io_redirect")),
   };
 
   let (op, io_file) = parse_io_file(op_and_file)?;
@@ -974,10 +979,10 @@ fn parse_io_file(pair: Pair<Rule>) -> Result<(RedirectOp, IoFile)> {
   let mut inner = pair.into_inner();
   let op = inner
     .next()
-    .ok_or_else(|| anyhow!("Expected redirection operator"))?;
+    .ok_or_else(|| miette!("Expected redirection operator"))?;
   let filename = inner
     .next()
-    .ok_or_else(|| anyhow!("Expected filename after redirection operator"))?;
+    .ok_or_else(|| miette!("Expected filename after redirection operator"))?;
 
   let redirect_op = match op.as_rule() {
     Rule::LESS => RedirectOp::Input(RedirectOpInput::Redirect),
@@ -996,7 +1001,7 @@ fn parse_io_file(pair: Pair<Rule>) -> Result<(RedirectOp, IoFile)> {
           IoFile::Fd(fd),
         ));
       } else {
-        return Err(anyhow!(
+        return Err(miette!(
           "Expected a number after {} operator",
           if op.as_rule() == Rule::LESSAND {
             "<&"
@@ -1007,7 +1012,7 @@ fn parse_io_file(pair: Pair<Rule>) -> Result<(RedirectOp, IoFile)> {
       }
     }
     _ => {
-      return Err(anyhow!(
+      return Err(miette!(
         "Unexpected redirection operator: {:?}",
         op.as_rule()
       ))
@@ -1017,7 +1022,7 @@ fn parse_io_file(pair: Pair<Rule>) -> Result<(RedirectOp, IoFile)> {
   let io_file = if filename.as_rule() == Rule::FILE_NAME_PENDING_WORD {
     IoFile::Word(parse_word(filename)?)
   } else {
-    return Err(anyhow!(
+    return Err(miette!(
       "Unexpected filename type: {:?}",
       filename.as_rule()
     ));
@@ -1054,7 +1059,7 @@ mod test {
   fn test_sequential_list() {
     let parse_and_create = |input: &str| -> Result<SequentialList> {
       let pairs = ShellParser::parse(Rule::complete_command, input)
-        .map_err(|e| anyhow::Error::msg(e.to_string()))?
+        .map_err(|e| miette!(e.to_string()))?
         .next()
         .unwrap();
       //   println!("pairs: {:?}", pairs);
@@ -1343,9 +1348,9 @@ mod test {
 
   #[test]
   fn test_env_var() {
-    let parse_and_create = |input: &str| -> Result<EnvVar, anyhow::Error> {
+    let parse_and_create = |input: &str| -> Result<EnvVar, miette::Error> {
       let pairs = ShellParser::parse(Rule::ASSIGNMENT_WORD, input)
-        .map_err(|e| anyhow::anyhow!(e.to_string()))?
+        .map_err(|e| miette!(e.to_string()))?
         .next()
         .unwrap();
       parse_env_var(pairs)

--- a/crates/deno_task_shell/src/shell/command.rs
+++ b/crates/deno_task_shell/src/shell/command.rs
@@ -13,7 +13,7 @@ use crate::ExecuteResult;
 use crate::FutureExecuteResult;
 use crate::ShellCommand;
 use crate::ShellCommandContext;
-use anyhow::Result;
+use miette::{miette, Result};
 use futures::FutureExt;
 use thiserror::Error;
 
@@ -87,15 +87,21 @@ enum ResolveCommandError {
 enum FailedShebangError {
   #[error(transparent)]
   CommandPath(#[from] ResolveCommandPathError),
-  #[error(transparent)]
-  Any(#[from] anyhow::Error),
+  #[error("{0}")]
+  MietteError(String),
+}
+
+impl From<miette::Error> for FailedShebangError {
+  fn from(err: miette::Error) -> Self {
+    FailedShebangError::MietteError(err.to_string())
+  }
 }
 
 impl FailedShebangError {
   pub fn exit_code(&self) -> i32 {
     match self {
       FailedShebangError::CommandPath(err) => err.exit_code(),
-      FailedShebangError::Any(_) => 1,
+      FailedShebangError::MietteError(_) => 1,
     }
   }
 }
@@ -119,12 +125,12 @@ async fn resolve_command<'a>(
   // won't have a script with a shebang in it on Windows
   if command_name.name.contains('/') {
     if let Some(shebang) = resolve_shebang(&command_path).map_err(|err| {
-      ResolveCommandError::FailedShebang(FailedShebangError::Any(err.into()))
+      ResolveCommandError::FailedShebang(FailedShebangError::MietteError(err.to_string()))
     })? {
       let (shebang_command_name, mut args) = if shebang.string_split {
         let mut args = parse_shebang_args(&shebang.command, context)
           .await
-          .map_err(FailedShebangError::Any)?;
+          .map_err(|e| FailedShebangError::MietteError(e.to_string()))?;
         args.push(command_path.to_string_lossy().to_string());
         (args.remove(0), args)
       } else {
@@ -155,7 +161,7 @@ async fn parse_shebang_args(
   context: &ShellCommandContext,
 ) -> Result<Vec<String>> {
   fn err_unsupported(text: &str) -> Result<Vec<String>> {
-    anyhow::bail!("unsupported shebang. Please report this as a bug (https://github.com/denoland/deno).\n\nShebang: {}", text)
+    miette::bail!("unsupported shebang. Please report this as a bug (https://github.com/denoland/deno).\n\nShebang: {}", text)
   }
 
   let mut args = crate::parser::parse(text)?;
@@ -190,15 +196,14 @@ async fn parse_shebang_args(
     return err_unsupported(text);
   }
 
-  Ok(
-    super::execute::evaluate_args(
+  super::execute::evaluate_args(
       cmd.args,
       &context.state,
       context.stdin.clone(),
       context.stderr.clone(),
     )
-    .await?,
-  )
+    .await
+    .map_err(|e| miette!(e.to_string()))
 }
 
 /// Errors for executable commands.
@@ -226,7 +231,8 @@ pub fn resolve_command_path(
   state: &ShellState,
 ) -> Result<PathBuf, ResolveCommandPathError> {
   resolve_command_path_inner(command_name, base_dir, state, || {
-    Ok(std::env::current_exe()?)
+    std::env::current_exe()
+      .map_err(|e| miette!(e.to_string()))
   })
 }
 

--- a/crates/deno_task_shell/src/shell/command.rs
+++ b/crates/deno_task_shell/src/shell/command.rs
@@ -13,8 +13,8 @@ use crate::ExecuteResult;
 use crate::FutureExecuteResult;
 use crate::ShellCommand;
 use crate::ShellCommandContext;
-use miette::{miette, Result};
 use futures::FutureExt;
+use miette::{miette, Result};
 use thiserror::Error;
 
 #[derive(Debug, Clone)]
@@ -125,7 +125,9 @@ async fn resolve_command<'a>(
   // won't have a script with a shebang in it on Windows
   if command_name.name.contains('/') {
     if let Some(shebang) = resolve_shebang(&command_path).map_err(|err| {
-      ResolveCommandError::FailedShebang(FailedShebangError::MietteError(err.to_string()))
+      ResolveCommandError::FailedShebang(FailedShebangError::MietteError(
+        err.to_string(),
+      ))
     })? {
       let (shebang_command_name, mut args) = if shebang.string_split {
         let mut args = parse_shebang_args(&shebang.command, context)
@@ -197,13 +199,13 @@ async fn parse_shebang_args(
   }
 
   super::execute::evaluate_args(
-      cmd.args,
-      &context.state,
-      context.stdin.clone(),
-      context.stderr.clone(),
-    )
-    .await
-    .map_err(|e| miette!(e.to_string()))
+    cmd.args,
+    &context.state,
+    context.stdin.clone(),
+    context.stderr.clone(),
+  )
+  .await
+  .map_err(|e| miette!(e.to_string()))
 }
 
 /// Errors for executable commands.
@@ -231,8 +233,7 @@ pub fn resolve_command_path(
   state: &ShellState,
 ) -> Result<PathBuf, ResolveCommandPathError> {
   resolve_command_path_inner(command_name, base_dir, state, || {
-    std::env::current_exe()
-      .map_err(|e| miette!(e.to_string()))
+    std::env::current_exe().map_err(|e| miette!(e.to_string()))
   })
 }
 

--- a/crates/shell/src/execute.rs
+++ b/crates/shell/src/execute.rs
@@ -7,12 +7,13 @@ use deno_task_shell::{
 pub async fn execute_inner(text: &str, state: ShellState) -> anyhow::Result<ExecuteResult> {
     let list = deno_task_shell::parser::parse(text);
 
-    let stderr = ShellPipeWriter::stderr();
+    let mut stderr = ShellPipeWriter::stderr();
     let stdout = ShellPipeWriter::stdout();
     let stdin = ShellPipeReader::stdin();
 
     if let Err(e) = list {
-        anyhow::bail!("Syntax error: {}", e);
+        stderr.write_all(format!("Syntax error: {:?}", e).as_bytes())?;
+        return Ok(ExecuteResult::Exit(1, vec![]));
     }
 
     // spawn a sequential list and pipe its output to the environment


### PR DESCRIPTION
This implements basic migration miette. #77 
Pest uses miette for error reporting now - this has been fixed. 
The rest of the errors do not implement miette's fancy features. I want to use the fancy features for errors created on ast level. 
I will implement those in a separate PR. 
Closes #86 