### PR TITLE
Set Ctrl-C signal handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +286,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+dependencies = [
+ "nix 0.29.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -748,7 +764,19 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -1086,7 +1114,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.28.0",
  "radix_trie",
  "rustyline-derive",
  "unicode-segmentation",
@@ -1167,6 +1195,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ctrlc",
  "deno_task_shell",
  "dirs",
  "futures",
@@ -1468,7 +1497,7 @@ dependencies = [
  "glob",
  "itertools",
  "libc",
- "nix",
+ "nix 0.28.0",
  "number_prefix",
  "once_cell",
  "os_display",

--- a/crates/shell/Cargo.toml
+++ b/crates/shell/Cargo.toml
@@ -34,6 +34,7 @@ dirs = "5.0.1"
 which = "6.0.3"
 uu_uname = "0.0.27"
 uu_date = "0.0.27"
+ctrlc = "3.4.5"
 
 [package.metadata.release]
 # Dont publish the binary

--- a/crates/shell/src/main.rs
+++ b/crates/shell/src/main.rs
@@ -35,6 +35,11 @@ async fn interactive() -> anyhow::Result<()> {
         .completion_type(CompletionType::Circular)
         .build();
 
+    ctrlc::set_handler(move || {
+        println!("Received Ctrl+C");
+    })
+    .expect("Error setting Ctrl-C handler");
+
     let mut rl = Editor::with_config(config)?;
 
     let helper = helper::ShellPromptHelper::default();


### PR DESCRIPTION
This allows to catch Ctrl-C from within a running command, but unfortunately still exits. Also there seems to be some thread (?) still running in the background, since I get some later error message while I am already back in Bash:
```console
~/repos/shell(ctrl_c2)$ cat
^CReceived Ctrl+C

~/repos/shell(ctrl_c2)$ cat: Input/output error (os error 5)
Error: Errno(EIO)

~/repos/shell(ctrl_c2)$
```

Fixes #120.