### PR TITLE
feat Add date support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +750,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -828,6 +853,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "parse_datetime"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8720474e3dd4af20cea8716703498b9f3b690f318fa9d9d9e2e38eaf44b96d0"
+dependencies = [
+ "chrono",
+ "nom",
+ "regex",
 ]
 
 [[package]]
@@ -989,6 +1025,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +1172,7 @@ dependencies = [
  "futures",
  "rustyline",
  "tokio",
+ "uu_date",
  "uu_ls",
  "uu_uname",
  "which",
@@ -1346,6 +1412,20 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uu_date"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b64040b532d67a399c8670da5c5ba12bf38ee8b9d845330580f3ba7b1eabc7"
+dependencies = [
+ "chrono",
+ "clap",
+ "libc",
+ "parse_datetime",
+ "uucore",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "uu_ls"

--- a/crates/shell/Cargo.toml
+++ b/crates/shell/Cargo.toml
@@ -33,6 +33,7 @@ uu_ls = "0.0.27"
 dirs = "5.0.1"
 which = "6.0.3"
 uu_uname = "0.0.27"
+uu_date = "0.0.27"
 
 [package.metadata.release]
 # Dont publish the binary

--- a/crates/shell/src/commands/date.rs
+++ b/crates/shell/src/commands/date.rs
@@ -1,0 +1,31 @@
+use std::ffi::OsString;
+
+use deno_task_shell::{ExecuteResult, ShellCommand, ShellCommandContext};
+use futures::future::LocalBoxFuture;
+use uu_date::uumain as uu_date;
+
+pub struct DateCommand;
+
+impl ShellCommand for DateCommand {
+    fn execute(&self, mut context: ShellCommandContext) -> LocalBoxFuture<'static, ExecuteResult> {
+        Box::pin(futures::future::ready(match execute_date(&mut context) {
+            Ok(_) => ExecuteResult::from_exit_code(0),
+            Err(exit_code) => ExecuteResult::from_exit_code(exit_code),
+        }))
+    }
+}
+
+fn execute_date(context: &mut ShellCommandContext) -> Result<(), i32> {
+    let mut args: Vec<OsString> = vec![OsString::from("date")];
+
+    context
+        .args
+        .iter()
+        .for_each(|arg| args.push(OsString::from(arg)));
+
+    let exit_code = uu_date(args.into_iter());
+    if exit_code != 0 {
+        return Err(exit_code);
+    }
+    Ok(())
+}

--- a/crates/shell/src/commands/mod.rs
+++ b/crates/shell/src/commands/mod.rs
@@ -7,9 +7,11 @@ use uu_ls::uumain as uu_ls;
 
 use crate::execute;
 
+pub mod date;
 pub mod uname;
 pub mod which;
 
+pub use date::DateCommand;
 pub use uname::UnameCommand;
 pub use which::WhichCommand;
 
@@ -43,6 +45,10 @@ pub fn get_commands() -> HashMap<String, Rc<dyn ShellCommand>> {
         (
             "uname".to_string(),
             Rc::new(UnameCommand) as Rc<dyn ShellCommand>,
+        ),
+        (
+            "date".to_string(),
+            Rc::new(DateCommand) as Rc<dyn ShellCommand>,
         ),
     ])
 }

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -870,6 +870,23 @@ async fn arithmetic() {
         .await;
 }
 
+#[tokio::test]
+async fn date() {
+    TestBuilder::new()
+        .command("date")
+        .assert_exit_code(0)
+        .check_stdout(false)
+        .run()
+        .await;
+
+    TestBuilder::new()
+        .command("date +%Y-%m-%d")
+        .assert_exit_code(0)
+        .check_stdout(false)
+        .run()
+        .await;
+}
+
 #[cfg(test)]
 fn no_such_file_error_text() -> &'static str {
     if cfg!(windows) {


### PR DESCRIPTION
Closes #146 
It uses `uu_date` to handle date command. However, I noticed it does not support commands like:
`date -r Cargo.toml`. I will open a PR soon to `uu_date` to add support for this. 