### PR TITLE
Fix the syntax in if_else.sh

### DIFF
--- a/scripts/if_else.sh
+++ b/scripts/if_else.sh
@@ -1,7 +1,7 @@
 FOO=2
-if [[ $FOO -eq 1 ]] then
+if [[ $FOO -eq 1 ]]; then
     echo "FOO is 1"
-elif [[ $FOO -eq 2 ]] then  
+elif [[ $FOO -eq 2 ]]; then
     echo "FOO is 2"
 else
     echo "FOO is not 1 or 2"


### PR DESCRIPTION
The test script `if_else.sh` has incorrect syntax for an if statement:

    $ bash if_else.sh
    if_else.sh: line 2: syntax error near unexpected token `then'
    if_else.sh: line 2: `if [[ $FOO -eq 1 ]] then'

The correct syntax uses `;` before `then`.

Unfortunately this correct syntax does not parse:
```
Syntax error:   × Failed to parse input
  ╰─▶ Failure to parse at Pos((2, 16))
   ╭────
 1 │ if [[ $FOO -eq 1 ]]; then
   ·                ┬
   ·                ╰── expected TILDE_PREFIX, UNQUOTED_ESCAPE_CHAR, SUB_COMMAND, or EXIT_STATUS
   ╰────
  help: expected TILDE_PREFIX, UNQUOTED_ESCAPE_CHAR, SUB_COMMAND,
        or EXIT_STATUS
```