### PR TITLE
206 sourcing a file will lose the current path value

### DIFF
--- a/crates/deno_task_shell/src/shell/commands/exit.rs
+++ b/crates/deno_task_shell/src/shell/commands/exit.rs
@@ -19,10 +19,10 @@ impl ShellCommand for ExitCommand {
     mut context: ShellCommandContext,
   ) -> LocalBoxFuture<'static, ExecuteResult> {
     let result = match execute_exit(context.args) {
-      Ok(code) => ExecuteResult::Exit(code, Vec::new()),
+      Ok(code) => ExecuteResult::Exit(code, Vec::new(), Vec::new()),
       Err(err) => {
         context.stderr.write_line(&format!("exit: {err}")).unwrap();
-        ExecuteResult::Exit(2, Vec::new())
+        ExecuteResult::Exit(2, Vec::new(), Vec::new())
       }
     };
     Box::pin(futures::future::ready(result))

--- a/crates/deno_task_shell/src/shell/execute.rs
+++ b/crates/deno_task_shell/src/shell/execute.rs
@@ -135,7 +135,7 @@ pub async fn execute_with_pipes(
   .await;
 
   match result {
-    ExecuteResult::Exit(code, _) => code,
+    ExecuteResult::Exit(code, _, _) => code,
     ExecuteResult::Continue(exit_code, _, _) => exit_code,
   }
 }
@@ -183,7 +183,10 @@ pub fn execute_sequential_list(
         )
         .await;
         match result {
-          ExecuteResult::Exit(exit_code, handles) => {
+          ExecuteResult::Exit(exit_code, changes, handles) => {
+            state.apply_changes(&changes);
+            state.set_shell_var("?", &exit_code.to_string());
+            final_changes.extend(changes);
             async_handles.extend(handles);
             final_exit_code = exit_code;
             was_exit = true;
@@ -215,7 +218,7 @@ pub fn execute_sequential_list(
     }
 
     if was_exit {
-      ExecuteResult::Exit(final_exit_code, async_handles)
+      ExecuteResult::Exit(final_exit_code, final_changes, async_handles)
     } else {
       ExecuteResult::Continue(final_exit_code, final_changes, async_handles)
     }
@@ -287,7 +290,7 @@ fn execute_sequence(
         )
         .await;
         let (exit_code, mut async_handles) = match first_result {
-          ExecuteResult::Exit(_, _) => return first_result,
+          ExecuteResult::Exit(_, _, _) => return first_result,
           ExecuteResult::Continue(exit_code, sub_changes, async_handles) => {
             changes.extend(sub_changes);
             (exit_code, async_handles)
@@ -317,9 +320,10 @@ fn execute_sequence(
           let next_result =
             execute_sequence(next, state, stdin, stdout, stderr).await;
           match next_result {
-            ExecuteResult::Exit(code, sub_handles) => {
+            ExecuteResult::Exit(code, sub_changes, sub_handles) => {
+              changes.extend(sub_changes);
               async_handles.extend(sub_handles);
-              ExecuteResult::Exit(code, async_handles)
+              ExecuteResult::Exit(code, changes, async_handles)
             }
             ExecuteResult::Continue(exit_code, sub_changes, sub_handles) => {
               changes.extend(sub_changes);
@@ -350,7 +354,9 @@ async fn execute_pipeline(
     execute_pipeline_inner(pipeline.inner, state, stdin, stdout, stderr).await;
   if pipeline.negated {
     match result {
-      ExecuteResult::Exit(code, handles) => ExecuteResult::Exit(code, handles),
+      ExecuteResult::Exit(code, changes, handles) => {
+        ExecuteResult::Exit(code, changes, handles)
+      }
       ExecuteResult::Continue(code, changes, handles) => {
         let new_code = if code == 0 { 1 } else { 0 };
         ExecuteResult::Continue(new_code, changes, handles)
@@ -570,8 +576,8 @@ async fn execute_command(
     CommandInner::Subshell(list) => {
       // Here the state can be changed but we can not pass by reference
       match execute_subshell(list, state, stdin, stdout, stderr).await {
-        ExecuteResult::Exit(code, handles) => {
-          ExecuteResult::Exit(code, handles)
+        ExecuteResult::Exit(code, _, handles) => {
+          ExecuteResult::Exit(code, changes, handles)
         }
         ExecuteResult::Continue(code, _, handles) => {
           ExecuteResult::Continue(code, changes, handles)
@@ -642,7 +648,8 @@ async fn execute_for_clause(
     .await;
 
     match result {
-      ExecuteResult::Exit(code, handles) => {
+      ExecuteResult::Exit(code, env_changes, handles) => {
+        changes.extend(env_changes);
         async_handles.extend(handles);
         last_exit_code = code;
         break;
@@ -658,7 +665,7 @@ async fn execute_for_clause(
   state.apply_changes(&changes);
 
   if state.exit_on_error() && last_exit_code != 0 {
-    ExecuteResult::Exit(last_exit_code, async_handles)
+    ExecuteResult::Exit(last_exit_code, changes, async_handles)
   } else {
     ExecuteResult::Continue(last_exit_code, changes, async_handles)
   }
@@ -910,7 +917,8 @@ async fn execute_pipe_sequence(
   let mut changes: Vec<EnvChange> = changes.into_iter().flatten().collect();
 
   match last_result {
-    ExecuteResult::Exit(code, mut handles) => {
+    ExecuteResult::Exit(code, env_changes, mut handles) => {
+      changes.extend(env_changes);
       handles.extend(all_handles);
       ExecuteResult::Continue(code, changes, handles)
     }
@@ -941,9 +949,9 @@ async fn execute_subshell(
   .await;
 
   match result {
-    ExecuteResult::Exit(code, handles) => {
+    ExecuteResult::Exit(code, env_changes, handles) => {
       // sub shells do not cause an exit
-      ExecuteResult::Continue(code, Vec::new(), handles)
+      ExecuteResult::Continue(code, env_changes, handles)
     }
     ExecuteResult::Continue(code, env_changes, handles) => {
       // env changes are not propagated
@@ -988,8 +996,9 @@ async fn execute_if_clause(
         )
         .await;
         match exec_result {
-          ExecuteResult::Exit(code, handles) => {
-            return ExecuteResult::Exit(code, handles);
+          ExecuteResult::Exit(code, env_changes, handles) => {
+            changes.extend(env_changes);
+            return ExecuteResult::Exit(code, changes, handles);
           }
           ExecuteResult::Continue(code, env_changes, handles) => {
             changes.extend(env_changes);
@@ -1019,8 +1028,9 @@ async fn execute_if_clause(
             )
             .await;
             match exec_result {
-              ExecuteResult::Exit(code, handles) => {
-                return ExecuteResult::Exit(code, handles);
+              ExecuteResult::Exit(code, env_changes, handles) => {
+                changes.extend(env_changes);
+                return ExecuteResult::Exit(code, changes, handles);
               }
               ExecuteResult::Continue(code, env_changes, handles) => {
                 changes.extend(env_changes);
@@ -1216,7 +1226,10 @@ async fn execute_simple_command(
 
   let result = execute_command_args(args, state, stdin, stdout, stderr).await;
   match result {
-    ExecuteResult::Exit(code, handles) => ExecuteResult::Exit(code, handles),
+    ExecuteResult::Exit(code, env_changes, handles) => {
+      changes.extend(env_changes);
+      ExecuteResult::Exit(code, changes, handles)
+    }
     ExecuteResult::Continue(code, env_changes, handles) => {
       changes.extend(env_changes);
       ExecuteResult::Continue(code, changes, handles)

--- a/crates/deno_task_shell/src/shell/types.rs
+++ b/crates/deno_task_shell/src/shell/types.rs
@@ -389,13 +389,13 @@ pub const CANCELLATION_EXIT_CODE: i32 = 130;
 
 #[derive(Debug)]
 pub enum ExecuteResult {
-  Exit(i32, Vec<JoinHandle<i32>>),
+  Exit(i32, Vec<EnvChange>, Vec<JoinHandle<i32>>),
   Continue(i32, Vec<EnvChange>, Vec<JoinHandle<i32>>),
 }
 
 impl ExecuteResult {
   pub fn for_cancellation() -> ExecuteResult {
-    ExecuteResult::Exit(CANCELLATION_EXIT_CODE, Vec::new())
+    ExecuteResult::Exit(CANCELLATION_EXIT_CODE, Vec::new(), Vec::new())
   }
 
   pub fn from_exit_code(exit_code: i32) -> ExecuteResult {
@@ -404,7 +404,7 @@ impl ExecuteResult {
 
   pub fn into_exit_code_and_handles(self) -> (i32, Vec<JoinHandle<i32>>) {
     match self {
-      ExecuteResult::Exit(code, handles) => (code, handles),
+      ExecuteResult::Exit(code, _, handles) => (code, handles),
       ExecuteResult::Continue(code, _, handles) => (code, handles),
     }
   }
@@ -415,7 +415,7 @@ impl ExecuteResult {
 
   pub fn into_changes(self) -> Vec<EnvChange> {
     match self {
-      ExecuteResult::Exit(_, _) => Vec::new(),
+      ExecuteResult::Exit(_, changes, _) => changes,
       ExecuteResult::Continue(_, changes, _) => changes,
     }
   }
@@ -424,14 +424,14 @@ impl ExecuteResult {
     self,
   ) -> (Vec<JoinHandle<i32>>, Vec<EnvChange>) {
     match self {
-      ExecuteResult::Exit(_, handles) => (handles, Vec::new()),
+      ExecuteResult::Exit(_, changes, handles) => (handles, changes),
       ExecuteResult::Continue(_, changes, handles) => (handles, changes),
     }
   }
 
   pub fn exit_code(&self) -> i32 {
     match self {
-      ExecuteResult::Exit(code, _) => *code,
+      ExecuteResult::Exit(code, _, _) => *code,
       ExecuteResult::Continue(code, _, _) => *code,
     }
   }

--- a/crates/deno_task_shell/src/shell/types.rs
+++ b/crates/deno_task_shell/src/shell/types.rs
@@ -428,6 +428,13 @@ impl ExecuteResult {
       ExecuteResult::Continue(_, changes, handles) => (handles, changes),
     }
   }
+
+  pub fn exit_code(&self) -> i32 {
+    match self {
+      ExecuteResult::Exit(code, _) => *code,
+      ExecuteResult::Continue(code, _, _) => *code,
+    }
+  }
 }
 
 /// Reader side of a pipe.

--- a/crates/shell/src/commands/set.rs
+++ b/crates/shell/src/commands/set.rs
@@ -17,7 +17,7 @@ impl ShellCommand for SetCommand {
             Ok((code, env_changes)) => ExecuteResult::Continue(code, env_changes, Vec::new()),
             Err(err) => {
                 context.stderr.write_line(&format!("set: {err}")).unwrap();
-                ExecuteResult::Exit(2, Vec::new())
+                ExecuteResult::Exit(2, Vec::new(), Vec::new())
             }
         };
         Box::pin(futures::future::ready(result))

--- a/crates/shell/src/execute.rs
+++ b/crates/shell/src/execute.rs
@@ -41,18 +41,15 @@ pub async fn execute(
     text: &str,
     filename: Option<String>,
     state: &mut ShellState,
-) -> miette::Result<i32> {
+) -> miette::Result<ExecuteResult> {
     let result = execute_inner(text, filename, state.clone()).await?;
 
-    match result {
-        ExecuteResult::Continue(exit_code, changes, _) => {
-            // set CWD to the last command's CWD
-            state.apply_changes(&changes);
-            std::env::set_current_dir(state.cwd())
-                .into_diagnostic()
-                .context("Failed to set CWD")?;
-            Ok(exit_code)
-        }
-        ExecuteResult::Exit(exit_code, _) => Ok(exit_code),
+    if let ExecuteResult::Continue(_, changes, _) = &result {
+        // set CWD to the last command's CWD
+        state.apply_changes(changes);
+        std::env::set_current_dir(state.cwd())
+            .into_diagnostic()
+            .context("Failed to set CWD")?;
     }
+    Ok(result)
 }

--- a/crates/shell/src/main.rs
+++ b/crates/shell/src/main.rs
@@ -189,7 +189,7 @@ async fn interactive(state: Option<ShellState>, norc: bool, args: &[String]) -> 
                     .context("Failed to execute")?;
                 state.set_last_command_exit_code(result.exit_code());
 
-                if let ExecuteResult::Exit(exit_code, _) = result {
+                if let ExecuteResult::Exit(exit_code, _, _) = result {
                     std::process::exit(exit_code);
                 }
             }

--- a/scripts/exit.sh
+++ b/scripts/exit.sh
@@ -1,0 +1,2 @@
+echo "Hello World"
+exit


### PR DESCRIPTION
Fixes #206. 
I also updated the behaviour of `exit` command in subshells. 
Before this PR: 
```sh
(exit)
```
would exit the shell. 
However, this is not expected behaviour and is fixed in this PR. 