### PR TITLE
Add support for `time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,18 +951,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8720474e3dd4af20cea8716703498b9f3b690f318fa9d9d9e2e38eaf44b96d0"
 dependencies = [
  "chrono",
- "nom",
+ "nom 7.1.3",
  "regex",
 ]
 
 [[package]]
 name = "parse_datetime"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae130e79b384861c193d6016a46baa2733a6f8f17486eb36a5c098c577ce01e8"
+checksum = "4bffd1156cebf13f681d7769924d3edfb9d9d71ba206a8d8e8e7eb9df4f4b1e7"
 dependencies = [
  "chrono",
- "nom",
+ "nom 8.0.0",
  "regex",
 ]
 
@@ -1326,7 +1335,7 @@ dependencies = [
  "futures",
  "libc",
  "miette",
- "parse_datetime 0.7.0",
+ "parse_datetime 0.8.0",
  "rustyline",
  "tokio",
  "uu_date",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,9 +692,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libredox"
@@ -1324,6 +1324,7 @@ dependencies = [
  "dtparse",
  "filetime",
  "futures",
+ "libc",
  "miette",
  "parse_datetime 0.7.0",
  "rustyline",

--- a/crates/deno_task_shell/src/grammar.pest
+++ b/crates/deno_task_shell/src/grammar.pest
@@ -168,7 +168,6 @@ Case = { "case" }
 Esac = { "esac" }
 While = _{ "while" }
 Until = _{ "until" }
-Time = { "time" }
 For = _{ "for" }
 Lbrace = { "{" }
 Rbrace = { "}" }
@@ -181,7 +180,7 @@ RESERVED_WORD = _{
     If | Then | Else | Elif | Fi | Do | Done |
     Case | Esac | While | Until | For |
     Lbrace | Rbrace | Bang | In |
-    StdoutStderr | Stdout | Time
+    StdoutStderr | Stdout
 }
 
 // Main grammar rules

--- a/crates/shell/Cargo.toml
+++ b/crates/shell/Cargo.toml
@@ -41,6 +41,7 @@ parse_datetime = "0.7.0"
 dtparse = "2.0.1"
 windows-sys = "0.59.0"
 ctrlc = "3.4.5"
+libc = "0.2.170"
 
 [package.metadata.release]
 # Dont publish the binary

--- a/crates/shell/Cargo.toml
+++ b/crates/shell/Cargo.toml
@@ -37,9 +37,9 @@ uu_date = "0.0.29"
 miette = { version = "7.5.0", features = ["fancy"] }
 filetime = "0.2.25"
 chrono = "0.4.39"
-parse_datetime = "0.7.0"
+parse_datetime = "0.8.0"
 dtparse = "2.0.1"
-windows-sys = "0.59.0"
+windows-sys = { version = "0.59.0", features = ["Win32_System_ProcessStatus", "Win32_Foundation", "Win32_System_Threading"] }
 ctrlc = "3.4.5"
 libc = "0.2.170"
 

--- a/crates/shell/Cargo.toml
+++ b/crates/shell/Cargo.toml
@@ -39,7 +39,7 @@ filetime = "0.2.25"
 chrono = "0.4.39"
 parse_datetime = "0.8.0"
 dtparse = "2.0.1"
-windows-sys = { version = "0.59.0", features = ["Win32_System_ProcessStatus", "Win32_Foundation", "Win32_System_Threading"] }
+windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_Threading"] }
 ctrlc = "3.4.5"
 libc = "0.2.170"
 

--- a/crates/shell/src/commands/mod.rs
+++ b/crates/shell/src/commands/mod.rs
@@ -10,6 +10,7 @@ use crate::execute;
 pub mod date;
 pub mod printenv;
 pub mod set;
+pub mod time;
 pub mod touch;
 pub mod uname;
 pub mod which;
@@ -17,6 +18,7 @@ pub mod which;
 pub use date::DateCommand;
 pub use printenv::PrintEnvCommand;
 pub use set::SetCommand;
+pub use time::TimeCommand;
 pub use touch::TouchCommand;
 pub use uname::UnameCommand;
 pub use which::WhichCommand;
@@ -75,6 +77,10 @@ pub fn get_commands() -> HashMap<String, Rc<dyn ShellCommand>> {
         (
             "clear".to_string(),
             Rc::new(ClearCommand) as Rc<dyn ShellCommand>,
+        ),
+        (
+            "time".to_string(),
+            Rc::new(TimeCommand) as Rc<dyn ShellCommand>,
         ),
     ])
 }

--- a/crates/shell/src/commands/time.rs
+++ b/crates/shell/src/commands/time.rs
@@ -7,9 +7,9 @@ use futures::future::LocalBoxFuture;
 use libc::{rusage, timeval, RUSAGE_CHILDREN};
 
 #[cfg(windows)]
-use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::Threading::GetProcessTimes;
 #[cfg(windows)]
-use windows_sys::Win32::System::ProcessStatus::{GetProcessTimes, FILETIME};
+use windows_sys::Win32::Foundation::{FILETIME, HANDLE};
 
 pub struct TimeCommand;
 

--- a/crates/shell/src/commands/time.rs
+++ b/crates/shell/src/commands/time.rs
@@ -7,9 +7,9 @@ use futures::future::LocalBoxFuture;
 use libc::{rusage, timeval, RUSAGE_CHILDREN};
 
 #[cfg(windows)]
-use windows_sys::Win32::System::Threading::GetProcessTimes;
-#[cfg(windows)]
 use windows_sys::Win32::Foundation::{FILETIME, HANDLE};
+#[cfg(windows)]
+use windows_sys::Win32::System::Threading::GetProcessTimes;
 
 pub struct TimeCommand;
 

--- a/crates/shell/src/commands/time.rs
+++ b/crates/shell/src/commands/time.rs
@@ -1,0 +1,174 @@
+use std::time::Instant;
+
+use deno_task_shell::{ExecuteResult, ShellCommand, ShellCommandContext};
+use futures::future::LocalBoxFuture;
+
+#[cfg(unix)]
+use libc::{rusage, timeval, RUSAGE_CHILDREN};
+
+#[cfg(windows)]
+use windows_sys::Win32::Foundation::HANDLE;
+#[cfg(windows)]
+use windows_sys::Win32::System::ProcessStatus::{GetProcessTimes, FILETIME};
+
+pub struct TimeCommand;
+
+impl ShellCommand for TimeCommand {
+    fn execute(&self, mut context: ShellCommandContext) -> LocalBoxFuture<'static, ExecuteResult> {
+        Box::pin(async move {
+            match execute_time(&mut context).await {
+                Ok(_) => ExecuteResult::from_exit_code(0),
+                Err(exit_code) => ExecuteResult::from_exit_code(exit_code),
+            }
+        })
+    }
+}
+
+#[cfg(unix)]
+fn timeval_to_seconds(tv: timeval) -> f64 {
+    tv.tv_sec as f64 + (tv.tv_usec as f64 / 1_000_000.0)
+}
+
+#[cfg(unix)]
+fn get_resource_usage() -> rusage {
+    let mut usage = unsafe { std::mem::zeroed::<rusage>() };
+    unsafe {
+        libc::getrusage(RUSAGE_CHILDREN, &mut usage);
+    }
+    usage
+}
+
+#[cfg(windows)]
+fn filetime_to_seconds(ft: FILETIME) -> f64 {
+    // Convert FILETIME to 100-nanosecond intervals, then to seconds
+    let time_value = ((ft.dwHighDateTime as u64) << 32) | (ft.dwLowDateTime as u64);
+    time_value as f64 / 10_000_000.0
+}
+
+#[cfg(windows)]
+fn get_process_times(handle: HANDLE) -> (f64, f64) {
+    // Initialize FILETIME structures
+    let mut creation_time = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    let mut exit_time = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    let mut kernel_time = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    let mut user_time = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+
+    unsafe {
+        GetProcessTimes(
+            handle,
+            &mut creation_time,
+            &mut exit_time,
+            &mut kernel_time,
+            &mut user_time,
+        );
+    }
+
+    // Convert to seconds
+    let kernel_seconds = filetime_to_seconds(kernel_time);
+    let user_seconds = filetime_to_seconds(user_time);
+
+    (user_seconds, kernel_seconds)
+}
+
+#[cfg(windows)]
+fn get_current_process_handle() -> HANDLE {
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+    unsafe { GetCurrentProcess() }
+}
+
+async fn execute_time(context: &mut ShellCommandContext) -> Result<(), i32> {
+    if context.args.is_empty() {
+        context
+            .stderr
+            .write_line("Usage: time COMMAND [ARGS...]")
+            .ok();
+        return Err(1);
+    }
+
+    let command_line = context.args.join(" ");
+
+    #[cfg(unix)]
+    let before_usage = get_resource_usage();
+
+    #[cfg(windows)]
+    let process_handle = get_current_process_handle();
+    #[cfg(windows)]
+    let (before_user, before_kernel) = get_process_times(process_handle);
+
+    let start = Instant::now();
+
+    let result = crate::execute::execute(&command_line, None, &mut context.state).await;
+
+    let duration = start.elapsed();
+
+    #[cfg(unix)]
+    let after_usage = get_resource_usage();
+
+    #[cfg(windows)]
+    let (after_user, after_kernel) = get_process_times(process_handle);
+
+    #[cfg(unix)]
+    let user_time =
+        timeval_to_seconds(after_usage.ru_utime) - timeval_to_seconds(before_usage.ru_utime);
+    #[cfg(unix)]
+    let sys_time =
+        timeval_to_seconds(after_usage.ru_stime) - timeval_to_seconds(before_usage.ru_stime);
+
+    #[cfg(windows)]
+    let user_time = after_user - before_user;
+    #[cfg(windows)]
+    let sys_time = after_kernel - before_kernel;
+
+    #[cfg(not(any(unix, windows)))]
+    let user_time = 0.0;
+    #[cfg(not(any(unix, windows)))]
+    let sys_time = 0.0;
+
+    let real_time = duration.as_secs_f64();
+    let cpu_time = user_time + sys_time;
+    let cpu_usage = if real_time > 0.0 {
+        (cpu_time / real_time) * 100.0
+    } else {
+        0.0
+    };
+
+    context
+        .stderr
+        .write_line(&format!("\nreal\t{:.3}s", real_time))
+        .ok();
+    context
+        .stderr
+        .write_line(&format!("user\t{:.3}s", user_time))
+        .ok();
+    context
+        .stderr
+        .write_line(&format!("sys\t{:.3}s", sys_time))
+        .ok();
+    context
+        .stderr
+        .write_line(&format!("cpu\t{:.1}%", cpu_usage))
+        .ok();
+
+    match result {
+        Ok(execute_result) => match execute_result.exit_code() {
+            0 => Ok(()),
+            code => Err(code),
+        },
+        Err(err) => {
+            context.stderr.write_line(&format!("Error: {}", err)).ok();
+            Err(1)
+        }
+    }
+}


### PR DESCRIPTION
I have implemented a basic implementation for adding `time` to shell but not sure about the behaviour on Windows. @certik Can you please check this on Windows? 