### PR TITLE
Run coverage only on main and tags

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,15 @@
 name: coverage
 
-on: [push]
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
 jobs:
   test:
     name: coverage


### PR DESCRIPTION
Currently, it triggers coverage run on each commit push.

Ex: https://github.com/kp992/shell/actions
cc @wolfv.