### PR TITLE
fix: allow `,` in unquoted words

### DIFF
--- a/crates/deno_task_shell/src/grammar.pest
+++ b/crates/deno_task_shell/src/grammar.pest
@@ -153,7 +153,7 @@ EXIT_STATUS = ${ "$?" }
 // Operators
 OPERATOR = _{
     AND_IF | OR_IF | DSEMI | DLESS | DGREAT | LESSAND | GREATAND | LESSGREAT | DLESSDASH | CLOBBER |
-    "," |"(" | ")" | "{" | "}" | ";" | "&" | "|" | "<" | ">"
+    "(" | ")" | "{" | "}" | ";" | "&" | "|" | "<" | ">"
 }
 
 // Reserved words

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -1479,6 +1479,17 @@ async fn test_reserved_substring() {
         .await;
 }
 
+#[tokio::test]
+async fn test_comma_unquoted() {
+    // Allow `,` in unquoted words
+    TestBuilder::new()
+        .command("echo a,b,c")
+        .assert_exit_code(0)
+        .assert_stdout("a,b,c\n")
+        .run()
+        .await;
+}
+
 #[cfg(test)]
 fn no_such_file_error_text() -> &'static str {
     if cfg!(windows) {


### PR DESCRIPTION
closes gh-257