### PR TITLE
Fix time command losing quoted arguments when re-parsing

### DIFF
--- a/crates/shell/src/commands/time.rs
+++ b/crates/shell/src/commands/time.rs
@@ -97,7 +97,28 @@ async fn execute_time(context: &mut ShellCommandContext) -> Result<(), i32> {
         return Err(1);
     }
 
-    let command_line = context.args.join(" ");
+    let command_line = context
+        .args
+        .iter()
+        .map(|arg| {
+            if arg.is_empty() {
+                "''".to_string()
+            } else if arg.contains(|c: char| {
+                c.is_whitespace()
+                    || matches!(
+                        c,
+                        '\'' | '"' | '\\' | '$' | '(' | ')' | '|' | '&' | ';' | '<' | '>'
+                            | '`' | '!' | '{' | '}' | '[' | ']' | '*' | '?' | '#' | '~'
+                    )
+            }) {
+                // Wrap in single quotes, escaping any internal single quotes
+                format!("'{}'", arg.replace('\'', "'\\''"))
+            } else {
+                arg.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
 
     #[cfg(unix)]
     let before_usage = get_resource_usage();

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -2218,6 +2218,34 @@ async fn test_brace_group() {
         .await;
 }
 
+#[tokio::test]
+async fn time_preserves_quoted_args() {
+    // time should preserve quoted arguments when re-parsing the command
+    // Note: time's execute uses raw stdout, so we can't assert_stdout here.
+    // Instead we verify commands succeed (exit code 0) and stderr contains timing info.
+    TestBuilder::new()
+        .command(r#"time echo "hello world""#)
+        .assert_stderr_contains("real")
+        .assert_exit_code(0)
+        .run()
+        .await;
+
+    TestBuilder::new()
+        .command(r#"time echo 'hello world'"#)
+        .assert_stderr_contains("real")
+        .assert_exit_code(0)
+        .run()
+        .await;
+
+    // Arguments with special shell characters should be preserved
+    TestBuilder::new()
+        .command(r#"time echo "foo(bar)""#)
+        .assert_stderr_contains("real")
+        .assert_exit_code(0)
+        .run()
+        .await;
+}
+
 #[cfg(test)]
 fn no_such_file_error_text() -> &'static str {
     if cfg!(windows) {


### PR DESCRIPTION
## Summary
- The `time` builtin joined its arguments with `args.join(" ")` and re-parsed the result, which destroyed all quoting information
- `time python -c "import torch"` would pass just `import` to Python (truncating the argument)
- `time python -c "print('ok')"` would fail with a shell parse error due to unquoted parentheses
- Fix: shell-quote arguments containing whitespace or special characters (using single-quote wrapping) before joining and re-parsing

## Test plan
- [x] Added `time_preserves_quoted_args` test covering double-quoted args, single-quoted args, and args with special characters like parentheses
- [x] All existing tests pass

https://claude.ai/code/session_01PQyPNXA8mZKTLkNfytRunv